### PR TITLE
ci: fix workflow not having permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: build
+permissions:
+  contents: read
 on:
   push:
     branches: [ 'main' ]

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,4 +1,6 @@
 name: cache
+permissions:
+  contents: read
 on:
   pull_request:
     types:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,6 @@
 name: e2e
+permissions:
+  contents: read
 on:
   push:
     branches: [ 'main' ]

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,4 +1,6 @@
 name: npm
+permissions:
+  contents: read
 on:
   push:
     branches: [ 'main' ]


### PR DESCRIPTION
Potential fix for [https://github.com/evva-sfw/nest-mqtt/security/code-scanning/5](https://github.com/evva-sfw/nest-mqtt/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimum required permissions for the workflow. Based on the tasks performed in the workflow, the `contents: read` permission is sufficient, as the workflow only needs to read repository contents to install dependencies and check the git status. No write permissions are required.

The `permissions` block will be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
