### PR TITLE
fix: make username optional as per IClientOptions

### DIFF
--- a/src/mqtt.interface.ts
+++ b/src/mqtt.interface.ts
@@ -16,9 +16,9 @@ export interface MqttConnectOptions extends IClientOptions {
   /**
    * MQTT username
    */
-  username: string;
+  username?: string;
   /**
-   * Mqtt password
+   * MQTT password
    */
   password?: string;
 


### PR DESCRIPTION
This PR will make the `username` property of `MqttConnectOptions` optional, to enable TLS configuration without a forced username.